### PR TITLE
Declare #threads in processes.

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -32,8 +32,6 @@ process GRNinference {
     cache 'deep'
     cpus params.threads
 
-    clusterOptions "-l nodes=1:ppn=${params.threads} -l pmem=2gb -l walltime=24:00:00 -A ${params.qsubaccount}"
-
     input:
     each runId from 1..nbRuns
     file TFs from tfs
@@ -57,8 +55,6 @@ process GRNinference {
 process cisTarget {
     cache 'deep'
     cpus params.threads
-
-    clusterOptions "-l nodes=1:ppn=${params.threads} -l pmem=2gb -l walltime=24:00:00 -A ${params.qsubaccount}"
 
     input:
     file exprMat from expr
@@ -87,8 +83,6 @@ process AUCell {
     cache 'deep'
     cpus params.threads
 
-    clusterOptions "-l nodes=1:ppn=${params.threads} -l pmem=1gb -l walltime=1:00:00 -A ${params.qsubaccount}"
-
     input:
     file exprMat from expr
     file reg from regulons
@@ -115,18 +109,18 @@ def save = {
         outDir = file( params.outdir+"/$run" )
     }
     result = outDir.mkdirs()
-    println result ? "$run finished." : "Cannot create directory: $outDir"   
+    println result ? "$run finished." : "Cannot create directory: $outDir"
     Channel
         .fromPath(it)
         .collectFile(name: "${filename}.${ext}", storeDir: outDir)
 }
 
-grn_save.subscribe { 
-    save(it) 
+grn_save.subscribe {
+    save(it)
 }
-regulons_save.subscribe { 
-    save(it) 
+regulons_save.subscribe {
+    save(it)
 }
-auc_mat.subscribe { 
-    save(it) 
+auc_mat.subscribe {
+    save(it)
 }

--- a/main.nf
+++ b/main.nf
@@ -30,6 +30,7 @@ def runName = { it.getName().split('__')[0] }
 
 process GRNinference {
     cache 'deep'
+    cpus params.threads
 
     clusterOptions "-l nodes=1:ppn=${params.threads} -l pmem=2gb -l walltime=24:00:00 -A ${params.qsubaccount}"
 
@@ -43,7 +44,7 @@ process GRNinference {
 
     """
     pyscenic grn \
-        --num_workers ${params.threads} \
+        --num_workers ${task.cpus} \
         -o "run_${runId}__adj.tsv" \
         --method ${params.grn} \
         --cell_id_attribute ${params.cell_id_attribute} \
@@ -55,6 +56,7 @@ process GRNinference {
 
 process cisTarget {
     cache 'deep'
+    cpus params.threads
 
     clusterOptions "-l nodes=1:ppn=${params.threads} -l pmem=2gb -l walltime=24:00:00 -A ${params.qsubaccount}"
 
@@ -77,12 +79,13 @@ process cisTarget {
         --gene_attribute ${params.gene_attribute} \
         --mode "dask_multiprocessing" \
         --output "${runName(adj)}__reg.csv" \
-        --num_workers ${params.threads} \
+        --num_workers ${task.cpus} \
     """
 }
 
 process AUCell {
     cache 'deep'
+    cpus params.threads
 
     clusterOptions "-l nodes=1:ppn=${params.threads} -l pmem=1gb -l walltime=1:00:00 -A ${params.qsubaccount}"
 
@@ -100,7 +103,7 @@ process AUCell {
         -o ${runName(reg)}__${params.output} \
         --cell_id_attribute ${params.cell_id_attribute} \
         --gene_attribute ${params.gene_attribute} \
-        --num_workers ${params.threads}
+        --num_workers ${task.cpus}
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,6 +26,7 @@ profiles {
     }
     qsub {
         process.executor = 'pbs'
+        clusterOptions = "-l nodes=1:ppn=${params.threads} -l pmem=2gb -l walltime=24:00:00 -A ${params.qsubaccount}"
     }
     docker {
         docker.enabled = true


### PR DESCRIPTION
## Declare #threads in processes.
This is important for proper resource management on HPCs.

---

## Move clusterOptions to config file.

Not every qsub-based cluster takes the same options.
It is, therefore, necessary that the user can specify the options.
On the system in our lab, the pipeline fails with the hardcoded cluster
options.